### PR TITLE
Update the Updater

### DIFF
--- a/PreBook/app/models/updater-model.js
+++ b/PreBook/app/models/updater-model.js
@@ -11,7 +11,7 @@ Updater Model - Mojo
 */
 
 var UpdaterModel = function() {
-    this.updateURL = "http://appcatalog.webosarchive.com/WebService/getLatestVersionInfo.php?app=";
+    this.updateURL = "http://appcatalog.webosarchive.org/WebService/getLatestVersionInfo.php?app=";
     this.lastUpdateResponse = null;
 };
 

--- a/PreBook/app/models/updater-model.js
+++ b/PreBook/app/models/updater-model.js
@@ -2,12 +2,12 @@
 Updater Model - Mojo
  Version 0.3
  Created: 2020
- Author: Jonathan Wise
+ Author: Jon W
  License: MIT
  Description: A model to check for and get updates from App Museum II web service.
     Does not require App Museum to be installed, but does require internet access, and Preware to do the actual install.
  Source: Find the latest version of this library and clean samples of how to use it on GitHub:
-    https://github.com/codepoet80/webos-catalog-frontend/tree/main/Examples
+    https://github.com/webOSArchive/webos-common/tree/main/UpdaterExample
 */
 
 var UpdaterModel = function() {


### PR DESCRIPTION
webOS Archive is moving to a .org domain. This PR updates the paths so that the updater continues to work -- just in case you ever do a new version!